### PR TITLE
fix tests

### DIFF
--- a/palTest.c
+++ b/palTest.c
@@ -1367,7 +1367,10 @@ static void t_obs( int * status ) {
         "3/H", status );
   viv( lstat, 0, "palObs", "retval", status );
 
-  lstat = palObs ( 84, NULL, shortname, sizeof(shortname),
+  /* the first argument here should be 1 greater than the number of items
+   * in const struct telData defined in palObs.c
+   */
+  lstat = palObs ( 86, NULL, shortname, sizeof(shortname),
                    longname, sizeof(longname), &w, &p, &h );
   vcs ( longname, "?", "palObs", "4/NAME", status );
   viv( lstat, -1, "palObs", "retval", status );


### PR DESCRIPTION
with the addition of APEX and NANTEN2, the 'out of bounds' test for
palObs() needs to be tweaked.
