### PR TITLE
include bsd/string.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,8 @@ AC_CHECK_FUNCS(copysign)
 AC_CHECK_FUNCS(isblank)
 
 dnl    Use strlcpy if it is available
-AC_SEARCH_LIBS([strlcpy], [bsd], [AC_CHECK_HEADERS([bsd/string.h])])
+AC_SEARCH_LIBS([strlcpy], [bsd])
+AS_IF([test "x$ac_cv_search_strlcpy" = "x-lbsd"], [AC_CHECK_HEADERS([bsd/string.h])])
 AC_CHECK_FUNCS([strlcpy])
 
 # Need the math library

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,7 @@ AC_CHECK_FUNCS(copysign)
 AC_CHECK_FUNCS(isblank)
 
 dnl    Use strlcpy if it is available
-AC_SEARCH_LIBS([strlcpy], [bsd])
+AC_SEARCH_LIBS([strlcpy], [bsd], [AC_CHECK_HEADERS([bsd/string.h])])
 AC_CHECK_FUNCS([strlcpy])
 
 # Need the math library

--- a/palDfltin.c
+++ b/palDfltin.c
@@ -119,6 +119,10 @@ static int ISBLANK( int c ) {
 
 #endif
 
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
+
 /* System include files */
 #include <stdlib.h>
 #include <string.h>

--- a/palObs.c
+++ b/palObs.c
@@ -132,6 +132,10 @@
 #  include <config.h>
 #endif
 
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
+
 #include <string.h>
 
 /* We prefer to use the starutil package. */

--- a/palVers.c
+++ b/palVers.c
@@ -69,6 +69,10 @@
 # include <config.h>
 #endif
 
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
+
 #include <string.h>
 
 /* This version is just a straight copy without putting ellipsis on the end. */


### PR DESCRIPTION
When using `strlcpy()` from libbsd, include the proper header.