### PR TITLE
Fix mapqkz

### DIFF
--- a/palMapqk.c
+++ b/palMapqk.c
@@ -50,6 +50,9 @@
 *
 *     If the parallax and proper motions are zero the palMapqkz
 *     routine can be used instead.
+*
+*     Strictly speaking, the function is not valid for solar-system
+*     sources, though the error will usually be extremely small.
 
 *  Authors:
 *     PTW: Patrick T. Wallace

--- a/palMapqkz.c
+++ b/palMapqkz.c
@@ -123,10 +123,9 @@ void palMapqkz ( double rm, double dm, double amprms[21], double *ra,
 
 /* Aberration. */
    p1dv = eraPdp( p1, abv );
-   p1dvp1 = p1dv + 1.0;
    w = 1.0 + p1dv / ( ab1 + 1.0 );
    for( i = 0; i < 3; i++ ) {
-      p2[i] = ( ( ab1 * p1[i] ) + ( w * abv[i] ) ) / p1dvp1;
+      p2[i] = ( ( ab1 * p1[i] ) + ( w * abv[i] ) );
    }
 
 /* Precession and nutation. */

--- a/palMapqkz.c
+++ b/palMapqkz.c
@@ -99,7 +99,7 @@ void palMapqkz ( double rm, double dm, double amprms[21], double *ra,
 
 /* Local Variables: */
    int i;
-   double ab1, abv[3], p[3], w, p1dv, p1dvp1, p2[3], p3[3];
+   double ab1, abv[3], p[3], w, p1dv, p2[3], p3[3];
    double gr2e, pde, pdep1, ehn[3], p1[3];
 
 /* Unpack scalar and vector parameters. */

--- a/palMapqkz.c
+++ b/palMapqkz.c
@@ -100,22 +100,33 @@ void palMapqkz ( double rm, double dm, double amprms[21], double *ra,
 /* Local Variables: */
    int i;
    double ab1, abv[3], p[3], w, p1dv, p1dvp1, p2[3], p3[3];
+   double gr2e, pde, pdep1, ehn[3], p1[3];
 
 /* Unpack scalar and vector parameters. */
    ab1 = amprms[11];
+   gr2e = amprms[7];
    for( i = 0; i < 3; i++ ) {
       abv[i] = amprms[i+8];
+      ehn[i] = amprms[i+4];
    }
 
 /* Spherical to x,y,z. */
    eraS2c( rm, dm, p );
 
+/* Light deflection (restrained within the Sun's disc) */
+   pde = eraPdp( p, ehn );
+   pdep1 = pde + 1.0;
+   w = gr2e / ( pdep1 > 1.0e-5 ? pdep1 : 1.0e-5 );
+   for( i = 0; i < 3; i++) {
+      p1[i] = p[i] + w * ( ehn[i] - pde * p[i] );
+   }
+
 /* Aberration. */
-   p1dv = eraPdp( p, abv );
+   p1dv = eraPdp( p1, abv );
    p1dvp1 = p1dv + 1.0;
    w = 1.0 + p1dv / ( ab1 + 1.0 );
    for( i = 0; i < 3; i++ ) {
-      p2[i] = ( ( ab1 * p[i] ) + ( w * abv[i] ) ) / p1dvp1;
+      p2[i] = ( ( ab1 * p1[i] ) + ( w * abv[i] ) ) / p1dvp1;
    }
 
 /* Precession and nutation. */

--- a/palTest.c
+++ b/palTest.c
@@ -1270,17 +1270,16 @@ static void t_mappa( int *status ) {
 }
 
 static void t_mapqkz( int *status ) {
-   double amprms[21],  ra, da;
+   double amprms[21],  ra, da, ra_c, da_c;
+
+   /* Run inputs through mapqk with zero proper motion, parallax
+      and radial velocity.  Then run the same inputs through mapqkz.
+      Verify that the results are the same */
    palMappa( 2010.0, 55927.0, amprms );
+   palMapqk(1.234, -0.567, 0.0, 0.0, 0.0, 0.0, amprms, &ra_c, &da_c);
    palMapqkz( 1.234, -0.567, amprms, &ra, &da );
-   vvd( ra, 1.2344879748414849807, 1.0E-12, "palMapqkz", "ra", status );
-   vvd( da, -0.56697099554368701746, 1.0E-12, "palMapqkz", "da", status );
-
-   /* Try the same with palMapqk and zero parallax and proper motion */
-   palMapqk( 1.234, -0.567, 0., 0., 0., 0., amprms, &ra, &da );
-   vvd( ra, 1.2344879748414849807, 1.0E-7, "palMapqkz", "ra", status );
-   vvd( da, -0.56697099554368701746, 1.0E-7, "palMapqkz", "da", status );
-
+   vvd( ra, ra_c, 1.0E-12, "palMapqkz", "ra", status );
+   vvd( da, da_c, 1.0E-12, "palMapqkz", "da", status );
 }
 
 static void t_ampqk( int *status ) {

--- a/palTest.c
+++ b/palTest.c
@@ -1282,6 +1282,13 @@ static void t_mapqk( int *status ) {
     double px, pm_ra, pm_dec, v_rad;
     double hour, min, sec, pi;
     pi = 3.14159265358979323846;
+
+    /*
+    The data below represents the position of Arcturus on
+    JD (UT) 2457000.375 as reported by
+    http://aa.usno.navy.mil/data/docs/geocentric.php
+    */
+
     hour = 360.0/24.0;
     min = hour/60.0;
     sec = min/60.0;

--- a/palTest.c
+++ b/palTest.c
@@ -1269,6 +1269,52 @@ static void t_mappa( int *status ) {
    vvec( 21, amprms, expected, "palMappa", status );
 }
 
+static void t_mapqk( int *status ) {
+    /* Test mapqk by taking the geocentric apparent positions of Arcturus
+       as downloaded from aa.usno.mil/data/docs/geocentric.php and trying
+       to calculate it from Arcturus' mean position, proper motion, parallax,
+       and radial velocity */
+
+    double amprms[21];
+    double ra_0, dec_0; /* mean position */
+    double ra_app, dec_app; /* geocentric apparent position */
+    double ra_test, dec_test;
+    double px, pm_ra, pm_dec, v_rad;
+    double hour, min, sec, pi;
+    pi = 3.14159265358979323846;
+    hour = 360.0/24.0;
+    min = hour/60.0;
+    sec = min/60.0;
+    ra_0 = 14.0*hour + 15.0*min + 39.67207*sec;
+    dec_0 = 19.0 + 10.0/60.0 + 56.673/3600.0;
+    ra_0 *= pi/180.0;
+    dec_0 *= pi/180.0;
+
+    pm_ra = -1.0939*pi/(180.0*3600.0);
+    pm_ra /= cos(dec_0);
+    pm_dec = -2.00006*pi/(180.0*3600.0);
+    v_rad = -5.19;
+    px = 0.08883*pi/(180.0*3600.0);
+
+    palMappa(2000.0, 56999.87537249177, amprms);  /* time is the TDB MJD calculated from
+                                                     a JD of 2457000.375 with astropy.time */
+
+    palMapqk(ra_0, dec_0, pm_ra, pm_dec, px, v_rad, amprms, &ra_test, &dec_test);
+
+    ra_app = 14.0*hour + 16.0*min + 19.59*sec;
+    dec_app = 19.0 + 6.0/60.0 + 19.56/3600.0;
+    ra_app *= pi/180.0;
+    dec_app *= pi/180.0;
+
+    /* find the angular distance from the known mean position
+       to the calculated mean postion */
+    double dd;
+    dd = palDsep(ra_test, dec_test, ra_app, dec_app);
+    dd *= (180.0*3600.0)/pi; /* convert to arcsec */
+    vvd( 0.0, dd, 0.1, "palMapqk", "distance", status);
+
+}
+
 static void t_mapqkz( int *status ) {
    double amprms[21],  ra, da, ra_c, da_c;
 
@@ -2026,6 +2072,7 @@ int main (void) {
   t_e2h(&status);
   t_map(&status);
   t_mappa(&status);
+  t_mapqk(&status);
   t_mapqkz(&status);
   t_moon(&status);
   t_nut(&status);


### PR DESCRIPTION
Mapqkz was missing the block of code that, in mapqk, accounts for light-deflection near the Sun.  After corresponding with Patrick Wallace, I added that code into mapqkz.  I then rewrote the unit tests for mapqk and mapqkz.  The test for mapqk now takes USNO data for the geocentric apparent position of Arcturus and tries to calculate it from Acturus' mean position and motion parameters.  The test for mapqkz sends identical inputs through mapqk and mapqkz and verifies that the same result comes out.