### PR TITLE
Check for _str[n]icmp for Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,12 @@ AC_SEARCH_LIBS([strlcpy], [bsd])
 AS_IF([test "x$ac_cv_search_strlcpy" = "x-lbsd"], [AC_CHECK_HEADERS([bsd/string.h])])
 AC_CHECK_FUNCS([strlcpy])
 
+dnl    Windows might not have str[n]casecmp
+AC_CHECK_FUNCS(strcasecmp)
+AC_CHECK_FUNCS(strncasecmp)
+AC_CHECK_FUNCS(_stricmp)
+AC_CHECK_FUNCS(_strnicmp)
+
 # Need the math library
 AC_CHECK_LIB([m],[sin])
 

--- a/palObs.c
+++ b/palObs.c
@@ -155,6 +155,10 @@ static void star__strellcpy( char * dest, const char * src, size_t size ) {
 #define star_strellcpy(dest, src, size) star__strellcpy(dest, src, size)
 #endif
 
+#if HAVE__STRICMP || defined(_WIN32) || defined(_WIN64)
+#define strcasecmp _stricmp
+#endif
+
 #include "pal.h"
 #include "palmac.h"
 

--- a/palPreces.c
+++ b/palPreces.c
@@ -83,10 +83,18 @@
 *-
 */
 
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
 #include "pal.h"
 #include "pal1sofa.h"
 
 #include <string.h>
+
+#if HAVE__STRNICMP || defined(_WIN32) || defined(_WIN64)
+#  define strncasecmp _strnicmp
+#endif
 
 void palPreces ( const char sys[3], double ep0, double ep1,
                  double *ra, double *dc ) {


### PR DESCRIPTION
These changes have been driven by Starlink/palpy#11 where it seems Windows does not have `strncasecmp` or `strcasecmp` available.