### PR TITLE
palIntin.c: Fix missing pointer deference.

### DIFF
--- a/palIntin.c
+++ b/palIntin.c
@@ -129,7 +129,7 @@ void palIntin( const char * string, int *nstrt,
      string first and look for the negative */
   hasminus = 0;
   ctemp = strstart;
-  while ( ctemp != '\0' ) {
+  while ( *ctemp != '\0' ) {
     if (isdigit(*ctemp)) break;
     /* Reset so that - 12345 is not a negative number */
     hasminus = 0;


### PR DESCRIPTION
This was highlighted by a GCC 9.3.0 warning:

```
palIntin.c: In function ‘palIntin’:
palIntin.c:132:17: warning: comparison between pointer and zero character constant [-Wpointer-compare]
  132 |   while ( ctemp != '\0' ) {
      |                 ^~
palIntin.c:132:11: note: did you mean to dereference the pointer?
  132 |   while ( ctemp != '\0' ) {
```

This currently checks the pointer for equality to a null byte, instead of the character-content.